### PR TITLE
Add jest testing infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,4 +34,11 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+# Testing
+
+Run unit tests with:
+
+```bash
+npm test
+```
 # down-by-the-river

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,16 @@
+const nextJest = require('next/jest')
+
+const createJestConfig = nextJest({
+  dir: './'
+})
+
+const customJestConfig = {
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
+  testEnvironment: 'jest-environment-jsdom',
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1',
+    '\\.(css|less|scss|sass)$': 'identity-obj-proxy'
+  }
+}
+
+module.exports = createJestConfig(customJestConfig)

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/extend-expect'

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "jest"
   },
   "dependencies": {
     "leaflet": "^1.9.4",
@@ -24,6 +25,11 @@
     "eslint": "^9",
     "eslint-config-next": "15.3.3",
     "tailwindcss": "^4",
-    "typescript": "^5"
+    "typescript": "^5",
+    "@testing-library/react": "^14",
+    "@testing-library/jest-dom": "^6",
+    "@types/jest": "^29",
+    "identity-obj-proxy": "^3",
+    "jest": "^29"
   }
 }

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { useEffect, useRef } from "react";
 import L from "leaflet";
 import "leaflet/dist/leaflet.css";
@@ -55,5 +57,5 @@ export default function Map() {
             });
     }, []);
 
-    return <div id='map' className='w-full h-full' />;
+    return <div id='map' data-testid='map' className='w-full h-full' />;
 }

--- a/src/components/__tests__/Map.test.tsx
+++ b/src/components/__tests__/Map.test.tsx
@@ -1,0 +1,21 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+import Map from '../Map'
+
+jest.mock('leaflet', () => ({
+  map: jest.fn(() => ({
+    setView: jest.fn().mockReturnThis(),
+  })),
+  tileLayer: jest.fn(() => ({ addTo: jest.fn() })),
+  geoJSON: jest.fn(() => ({
+    bindPopup: jest.fn().mockReturnThis(),
+    addTo: jest.fn(),
+  })),
+}))
+
+describe('Map', () => {
+  it('renders map container', () => {
+    const { container } = render(<Map />)
+    expect(container.querySelector('#map')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary
- add jest-based unit test setup
- include simple test for Map component
- document test command in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68402ed1a5d88325a2659d4326a6c99e